### PR TITLE
Add implementation plan for third-party function pack imports

### DIFF
--- a/agents/knowledge/actions.md
+++ b/agents/knowledge/actions.md
@@ -1,0 +1,71 @@
+# Actions and Custom Functions
+
+Actions are the core building blocks of Cherri programs. Each action corresponds to an Apple Shortcut action and accepts typed parameters.
+
+## Calling Actions
+Invoke actions like functions:
+```
+alert("Hello", "Title")
+resizeImage(image, "640", "480")
+```
+Parameters are passed positionally. Use string interpolation or variables to supply dynamic values.
+
+## Standard Actions
+Cherri ships with thousands of predefined actions organized in the `actions/` directory. Each action is defined using `#define action` and maps to a Shortcut identifier and its parameter keys. For example:
+```
+#define action 'exit' stop()
+#define action comment(rawtext text: 'WFCommentActionText')
+```
+You may call `stop()` or `comment('Some text')` directly after these definitions are loaded (automatically by the compiler).
+
+## Custom Actions
+Define new actions using the `action` keyword:
+```
+action add(number op1, number op2): number {
+    const result = op1 + op2
+    output("{result}")
+}
+```
+- Parameters specify type and name.
+- Return type follows a colon after the parameter list.
+- Use `output(value)` to return a result.
+- Recursion is supported as demonstrated in a `fibonacci` example.
+
+## Mapping to Existing Shortcuts
+`#define action` can expose existing Shortcut actions with custom parameter names and defaults:
+```
+#define action 'dropbox.savefile' saveToDropbox(
+    variable file: 'WFInput',
+    text path: 'WFFileDestinationPath',
+    bool ?overwrite: 'WFSaveFileOverwrite' = false
+) {
+    "WFAskWhereToSave": false
+}
+```
+The block may include additional key–value pairs that are always set when the action is used.
+
+## Raw Actions
+For actions not yet defined, use `rawAction` with an identifier and parameter dictionary:
+```
+rawAction("is.workflow.actions.alert", {
+    "WFAlertActionMessage": "Hello, world!",
+    "WFAlertActionTitle": "Alert"
+})
+```
+
+## Copy/Paste Blocks
+Reuse sequences of actions with macros:
+```
+copy snippet {
+    alert("Hello")
+}
+
+paste snippet
+paste snippet
+```
+Each `paste` inserts the copied actions at that location.
+
+## Output Management
+- Most actions output a value that becomes the implicit input for the next action.
+- Use `output(value)` in custom actions to set the action result.
+- Access `RepeatIndex` and other special variables inside loops to use intermediate results.

--- a/agents/knowledge/examples.md
+++ b/agents/knowledge/examples.md
@@ -1,0 +1,52 @@
+# Example Snippets
+
+## Hello World
+```
+/* Hello, World! */
+#define name Hello, Cherri!
+@message = "Hello, Cherri!"
+@title = "Alert"
+alert(message, "{title}")
+```
+
+## Loops and Conditionals
+```
+@count = 3
+repeat i for 6 {
+    if count == i {
+        alert("Reached {i}")
+    }
+}
+
+@items = list("a","b","c")
+for item in items {
+    alert(RepeatIndex,item)
+}
+```
+
+## Menu
+```
+menu "Choose" {
+    item "One":
+        alert("1")
+    item "Two":
+        alert("2")
+}
+```
+
+## Custom Action
+```
+action add(number a, number b): number {
+    const result = a + b
+    output("{result}")
+}
+@sum = add(2,2)
+show("{sum}")
+```
+
+## Import Question and Include
+```
+#question name "What is your name?" "Brandon"
+#include 'stdlib'
+alert(name, "User")
+```

--- a/agents/knowledge/modules.md
+++ b/agents/knowledge/modules.md
@@ -1,0 +1,40 @@
+# Modules, Includes, and Import Questions
+
+Cherri supports modular composition and shortcut metadata through preprocessor-style directives.
+
+## Definitions
+Use `#define` to set properties about the resulting Shortcut:
+```
+#define name MyShortcut
+#define color red
+#define glyph apple
+#define inputs image, text
+#define outputs app, file
+#define from menubar, sleepmode, onscreen, quickactions
+#define quickactions finder, services
+#define noinput getclipboard
+#define version 17
+```
+These directives correspond to Shortcut metadata such as display name, color, accepted inputs/outputs, platform availability, and default behavior when run from Quick Actions.
+
+## Including Files
+`#include 'file.cherri'` inlines another Cherri source file. Relative paths or extension-less names can be used. This enables splitting large projects into reusable modules or shared definitions such as `stdlib`.
+
+## Import Questions
+`#question variable "Prompt" "Default"` prompts the user when the shortcut is installed, storing the answer in a constant named after the variable.
+
+## Copy and Paste
+`copy name { ... }` saves a block of actions for reuse while `paste name` inserts it. This is useful for repeating sequences without introducing a custom action.
+
+## Building and Signing
+Run the compiler from the terminal:
+```
+cherri main.cherri
+```
+Use `--debug` for stack traces and a raw `.plist` output. Signing uses macOS facilities when available and falls back to a remote signing server if configured.
+
+## Embedding and External Resources
+- `embedFile(path)` base64‑encodes an asset for inclusion.
+- `import` option on the CLI can convert existing Shortcuts from iCloud links.
+
+These features allow large projects to be structured cleanly and deployed as fully signed Shortcuts.

--- a/agents/knowledge/overview.md
+++ b/agents/knowledge/overview.md
@@ -1,0 +1,25 @@
+# Cherri Language Overview
+
+Cherri is a domain-specific language that compiles directly into Apple Shortcuts. It allows developers to author complex shortcuts using a textual syntax similar to traditional programming languages. Key goals include maintainability for large projects, transparent mapping to native Shortcut actions, and low runtime memory usage.
+
+## Key Features
+- Desktop‑friendly development with CLI, VSCode extension, and macOS IDE
+- Syntax inspired by Go and Ruby with familiar constructs such as variables, conditionals, loops, and functions
+- Direct one-to-one translation to underlying Shortcut actions for easy debugging
+- Immutable constants and typed variables with inference
+- Include system for composing large projects from multiple files
+- Support for custom actions, enumerations, optionals, default values, and raw identifiers
+- Copy/paste blocks for reusable action snippets
+- Import questions to gather user input when shortcut is installed
+- Standard library (`stdlib.cherri`) providing helpers like JavaScript execution and VCard menus
+
+## Workflow
+1. Write `.cherri` source files using the language syntax.
+2. Compile with the `cherri` CLI:
+   ```bash
+   cherri my_shortcut.cherri
+   ```
+3. Optionally run with `--debug` to emit a `.plist` file and stack traces.
+4. The compiler outputs a signed Shortcut ready for use on iOS or macOS.
+
+Cherri encourages explicitness and minimal magic. Globals such as `ShortcutInput` and `CurrentDate` are constants, and most constructs map directly to Shortcuts actions to keep behavior predictable.

--- a/agents/knowledge/syntax.md
+++ b/agents/knowledge/syntax.md
@@ -1,0 +1,78 @@
+# Cherri Syntax and Grammar
+
+Cherri uses a concise syntax with significant whitespace only inside strings. Statements generally end at newlines. Comments may be written with `//` for single lines or `/* ... */` for blocks.
+
+## Variables and Constants
+- Variables start with `@` and can be assigned using `=`: `@name = "Brandon"`.
+- Immutable constants use the `const` keyword: `const greeting = "Hello"`.
+- Variables may declare a type with `:@type`: `@count: number`.
+- Strings support interpolation with `{expression}` inside double quotes.
+- Single quotes define raw strings that forbid interpolation and newlines but compile faster.
+
+## Collections
+- Arrays use `[item1, item2]` syntax and can mix types.
+- Dictionaries mirror JSON object syntax:
+  ```
+  @dict = {
+      "key": "value",
+      "nested": [1,2,3]
+  }
+  ```
+- Access dictionary values with `getValue(dict,"key")` or bracket syntax `dict['key']` (no interpolation).
+
+## Enumerations
+Declare enums with `enum`:
+```
+enum callType {
+    'Audio',
+    'Video'
+}
+```
+Enum members are quoted strings.
+
+## Expressions and Operators
+Cherri supports standard arithmetic and logical operators:
+`+`, `-`, `*`, `/`, `%`, `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `contains`, `!contains`, `beginsWith`, `endsWith`, and range `<>` for between checks.
+Compound assignments `+=`, `-=`, `*=`, `/=` are also available.
+
+## Control Flow
+### Conditionals
+```
+if condition {
+    // actions
+} else {
+    // alternative
+}
+```
+Multiple conditions can be combined with `&&` and `||`. Blocks close with `}` and optional `else`.
+
+### Loops
+- Repeat a fixed number of times: `repeat i for 6 { ... }`
+- Iterate over a collection: `for item in listVar { ... }`
+The special variable `RepeatIndex` provides the current iteration index inside `for` loops.
+
+### Menus
+Create interactive menus:
+```
+menu "Prompt" {
+    item "Option 1":
+        alert("You chose option 1")
+    item "Option 2":
+        alert("You chose option 2")
+}
+```
+
+## String and Type Utilities
+- Convert types using suffixes: `number.text` coerces a number to text.
+- Global constants like `ShortcutInput`, `CurrentDate`, and `Device` can be referenced directly or interpolated into strings.
+- `nil` represents an absent value and may be supplied to actions, loops, or comparisons.
+
+## Macros
+- `copy name { ... }` defines a reusable block of actions.
+- `paste name` inserts the copied block at that location.
+
+## File Structure
+Top-level directives begin with `#`:
+- `#define` sets metadata such as `color`, `glyph`, `name`, etc.
+- `#include 'file.cherri'` imports another Cherri file.
+- `#question var "Prompt" "Default"` asks for input when the shortcut is imported.

--- a/agents/knowledge/types.md
+++ b/agents/knowledge/types.md
@@ -1,0 +1,45 @@
+# Data Types and Conversions
+
+Cherri offers a rich type system with inference and explicit annotations.
+
+## Primitive Types
+- **text**: UTF‑8 strings. Interpolated with `{}` when in double quotes.
+- **rawtext**: Single‑quoted strings without interpolation or newlines.
+- **number**: Integer values.
+- **float**: Decimal numbers.
+- **bool**: `true` or `false`.
+- **date**: Date objects created with `date("October 5, 2022")` or derived from globals.
+- **nil**: Absence of value; may be passed to actions or compared directly.
+
+## Collections
+- **array**: Ordered list `[1, "two", true]`. Use `list("a","b")` to create from values.
+- **dictionary**: JSON-style map `{ "key": value }` supporting nested structures and arrays.
+
+## Type Annotations and Inference
+Variables can optionally declare a type: `@value: number`. When assigned, the compiler validates the type but also infers it from expressions.
+
+## Globals and Special Types
+Certain identifiers are predefined:
+- `ShortcutInput`, `CurrentDate`, `Clipboard`, `Device`, `Ask`, etc.
+- Globals are case-sensitive and behave like constants.
+
+## Type Casting
+- Use property-style accessors: `variable.text`, `variable.number`, etc.
+- `getAs` syntax retrieves values from dictionaries or globals: `Device['System Version'].text`.
+- In strings, casting can occur inline: `"Version {Device['OS']}"`.
+
+## Enumerations
+Enums constrain values to a predefined set:
+```
+enum callType {
+    'Audio',
+    'Video'
+}
+```
+Enum names can be used as parameter types for actions.
+
+## Optional Types
+Prefix a parameter with `?` to mark it optional in action definitions: `bool ?overwrite = false`.
+
+## Default Values
+Provide `= value` after a parameter or constant to supply a default.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,32 @@
+# Project Plan: Cherri Knowledge Base
+
+## Overview
+- **Objective**: Build a comprehensive knowledge base describing the Cherri language so an AI agent can generate complete iOS Shortcuts through code.
+- **Success Criteria**: Detailed markdown references covering syntax, types, actions, modules, and examples located under `agents/knowledge/`.
+- **Timeline**: 1 day
+- **Priority**: High
+
+## Technical Analysis
+- **Current State**: Repository contains the Cherri compiler, tests, and standard library but lacks consolidated knowledge files for AI usage.
+- **Proposed Solution**: Analyze language tokens, parser, tests, and standard library to author reference files describing constructs and usage patterns.
+- **Technology Stack**: Markdown documentation, Go tooling for validation (`go test`).
+- **Dependencies**: Existing source code, tests, and standard library.
+
+## Implementation Strategy
+- **Phase 1**: Establish planning and task tracking documents.
+- **Phase 2**: Extract language features from source and tests; draft knowledge files.
+- **Phase 3**: Validate compilation and examples via repository tests.
+- **Phase 4**: Finalize documentation and ensure accessibility for AI agents.
+
+## Risk Assessment
+- **Technical Risks**: Incomplete coverage of edge cases or future language changes.
+- **Business Risks**: Documentation may require updates as language evolves.
+- **Mitigation Strategies**: Derive information directly from parser and tests; organize files for easy maintenance.
+
+## Quality Gates
+- **Code Review**: Adhere to repository style; ensure clarity and accuracy.
+- **Testing**: Run `go test ./...` after changes.
+- **Security**: No runtime code; ensure no sensitive data in docs.
+- **Performance**: Not applicable for documentation.
+
+## Status: In Progress

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,52 @@
+# Task Breakdown: Cherri Knowledge Base
+
+## Task Categories
+
+### Setup & Configuration
+- [x] **TASK-001**: Create planning and task documentation
+  - **Priority**: High
+  - **Effort**: 1h
+  - **Dependencies**: None
+  - **Acceptance Criteria**: PLAN.md and TASKS.md committed
+  - **Status**: Complete
+
+### Core Development
+- [x] **TASK-002**: Analyze language syntax and features
+  - **Priority**: High
+  - **Effort**: 4h
+  - **Dependencies**: TASK-001
+  - **Acceptance Criteria**: Key constructs identified across codebase
+  - **Status**: Complete
+
+- [x] **TASK-003**: Generate knowledge base files under agents/knowledge
+  - **Priority**: High
+  - **Effort**: 4h
+  - **Dependencies**: TASK-002
+  - **Acceptance Criteria**: Knowledge files cover syntax, types, actions, modules, examples
+  - **Status**: Complete
+
+### Integration & Testing
+- [x] **TASK-004**: Run Go test suite
+  - **Priority**: Medium
+  - **Effort**: 1h
+  - **Dependencies**: TASK-003
+  - **Acceptance Criteria**: `go test ./...` passes
+  - **Status**: Complete
+
+### Deployment & Monitoring
+- [ ] **TASK-005**: Document knowledge base usage guidance
+  - **Priority**: Medium
+  - **Effort**: 1h
+  - **Dependencies**: TASK-003
+  - **Acceptance Criteria**: Reference in repository documentation
+  - **Status**: Not Started
+
+## Progress Summary
+- **Total Tasks**: 5
+- **Completed**: 4
+- **In Progress**: 0
+- **Remaining**: 1
+- **Overall Progress**: 80%
+
+## Notes
+- Future updates may add more examples and integration guidance.

--- a/plans/import_functions.md
+++ b/plans/import_functions.md
@@ -1,0 +1,120 @@
+# Problem statement
+Cherri can already model Apple Shortcuts actions via built-in definitions and `#define action`, but there is no first-class, low-friction mechanism to install, discover, import, and maintain third-party command packs (Toolbox Pro, Nautomate, GizmoPack, etc.) across compile, decompile, search, and docs workflows.
+## Current state (relevant architecture)
+Action metadata is represented by `actionDefinition` and supports declarative params, enums, static extra params, and custom check/make/decomp hooks (`action.go:74`).
+Built-in actions are hardcoded in `actions_std.go` (`actions_std.go:48`) and additional declarative actions are loaded from `#define action` parsing (`action.go:700`, `action.go:736`).
+Standard action categories are statically listed (`actions_std.go:2006`) and loaded through include injection (`actions_std.go:2035`, `actions_std.go:2075`).
+Include resolution currently supports embedded `actions/*`, `stdlib`, or local files (`includes.go:85`).
+Compile-time action lookup fails on unknown symbols and only suggests standard category includes (`parser.go:1489`, `actions_std.go:2087`).
+Decompiler identifier matching depends on what is loaded in `actions` and similarly only auto-inserts standard includes (`decompile.go:259`, `decompile.go:1060`, `decompile.go:1255`).
+Action search/docs are oriented around built-in categories (`search.go:15`, `docs.go:32`).
+## Goals
+Enable reusable third-party action packs with typed function calls (not raw actions), easy project-level import, deterministic resolution, and decompile round-tripping that can recover pack imports.
+Keep backwards compatibility with existing `#include` and `#define action` behavior.
+Support both curated official packs and user-local/private packs.
+## Non-goals (v1)
+No dynamic runtime introspection of installed iOS/macOS apps.
+No remote code execution or Go-plugin loading from third parties.
+No requirement to encode advanced `make/check/decomp` Go hooks in external packs for initial release.
+## Proposed mechanism: Function Packs
+### 1) Introduce a pack manifest + declarative catalog format
+Add a pack descriptor format (JSON) with strict schema versioning:
+- Pack identity: `id`, `displayName`, `version`, `author`, `homepage`.
+- Compatibility: minimum Cherri version, optional iOS range.
+- Source files: one or more Cherri definition files containing `enum` and `#define action` blocks.
+- Namespacing metadata: recommended function prefix (e.g., `tbp_`, `na_`, `gz_`) and collision policy.
+- Identifier index hints: optional mapping from full Shortcut identifier to function name for faster decompile matching.
+Keep action signatures in existing Cherri syntax to reuse current parser and avoid duplicating type systems.
+### 2) Add a pack registry/discovery subsystem
+Create a new loader layer (e.g., `function_packs.go`) that discovers manifests from:
+- Repo-local path (e.g., `./function-packs/`),
+- User path (e.g., `~/.config/cherri/function-packs/`),
+- Optional explicit CLI path (`--pack-dir`).
+For each pack: validate schema, resolve referenced files, and build in-memory indexes:
+- `packByID`,
+- `actionToPack` (function identifier -> pack),
+- `shortcutIdentifierToPackAction` (full workflow identifier -> pack/function).
+Registry load must be deterministic (stable sort by path + pack id) and fail-fast on invalid manifest.
+### 3) Add explicit source-level imports for packs
+Introduce a new directive, `#import 'pack-id'` (or equivalent), parsed during pre-processing before action calls are validated.
+Implementation touchpoints:
+- Add token for import directive (`token.go`).
+- Extend pre-parse flow to process imports alongside includes (`parser.go:108`, `includes.go:28`).
+- Resolve imported pack files into `lines` similarly to include expansion so `handleActionDefinitions()` can keep working unchanged (`action.go:700`).
+This keeps user ergonomics simple and avoids requiring full file paths in every project.
+### 4) Generalize "missing include" into "missing provider"
+Refactor `checkMissingStandardInclude` (`actions_std.go:2087`) into a provider-aware resolver:
+- First check local declared/imported actions.
+- If unresolved, check installed packs index.
+- If exactly one pack matches, emit targeted error: `Action 'x()' requires #import 'toolboxpro'`.
+- If multiple packs match, emit ambiguity error with candidate pack ids and require explicit import.
+Preserve current behavior for built-in `actions/*` categories.
+### 5) Define precedence and collision policy
+Adopt explicit resolution order:
+1. Local source `#define action` declarations.
+2. Imported function packs.
+3. Built-in standard actions.
+On name collisions between packs or with built-ins, require one of:
+- Pack-specific alias import (`#import 'toolboxpro' as 'tbp'`) plus generated prefixed names, or
+- Manifest-enforced prefixing.
+Do not silently override existing behavior.
+### 6) Decompile integration for third-party actions
+Enhance decompile matching so third-party actions round-trip:
+- Use pack identifier index while matching unknown `WFWorkflowActionIdentifier` (`decompile.go:1060`).
+- When matched to a pack action, emit `#import 'pack-id'` at file top (similar to `popLine` include insertion path in `decompile.go:1255`).
+- Retain `rawAction(...)` fallback when no pack/builtin mapping exists.
+This allows imported Shortcuts containing Toolbox Pro/Nautomate/GizmoPack actions to become maintainable Cherri source instead of opaque raw actions.
+### 7) CLI support for discoverability and maintenance
+Extend CLI arguments (`args.go:9`) with pack lifecycle commands:
+- `--list-packs` (show installed/discovered packs),
+- `--pack-info=<id>`,
+- `--pack-dir=<path>` (additional search root),
+- Optional future: `--install-pack=<url|path>` and `--update-packs`.
+Also extend `--action` search to show pack origin and availability (`search.go:15`).
+### 8) Docs generation integration
+Extend docs generation pipeline (`docs.go:32`) to optionally include packs:
+- `--docs=<pack-id>` or `--docs-pack=<id>` to render pack-specific action docs,
+- include manifest metadata (pack version/source) in header.
+This makes third-party catalogs self-documenting and easy to audit.
+### 9) Seed packs for popular ecosystems
+Create first-party maintained starter packs for:
+- Toolbox Pro,
+- Nautomate,
+- GizmoPack.
+Each pack should ship with:
+- manifest,
+- declarative action file(s),
+- enum definitions,
+- compatibility notes,
+- fixture Shortcuts or Cherri snippets for regression tests.
+### 10) Testing strategy
+Add tests covering:
+- Manifest parsing/validation failures and conflict detection.
+- Import directive parse + registry resolution.
+- Compile success for third-party action calls with typed args.
+- Undefined action diagnostics suggesting correct `#import`.
+- Decompile recovery: unknown identifier -> pack match -> top-level import insertion.
+- Backwards compatibility: existing standard action includes and tests remain green (`cherri_test.go:17`).
+## File-level implementation roadmap
+`token.go`: add import token.
+`parser.go`: parse/import directive handling in pre-parse pipeline; keep compile-time action collection semantics intact (`parser.go:108`, `parser.go:1489`).
+`includes.go`: unify include/import expansion pipeline, with separate resolvers for file includes vs pack imports (`includes.go:28`, `includes.go:85`).
+`action.go`: reuse existing action definition parsing; add optional source metadata for actions (origin pack id) when loaded (`action.go:74`, `action.go:736`).
+`actions_std.go`: refactor static include suggestion flow into pluggable provider resolver (`actions_std.go:2006`, `actions_std.go:2087`).
+`decompile.go`: integrate pack-aware identifier mapping and import insertion (`decompile.go:259`, `decompile.go:1060`, `decompile.go:1255`).
+`args.go`: register pack-related flags (`args.go:9`).
+`search.go`, `docs.go`: include pack-origin-aware discovery and docs output (`search.go:15`, `docs.go:32`).
+New files: pack manifest structs, schema validation, registry/index builder, and tests.
+## Rollout plan
+Phase 1: Internal pack registry + local filesystem packs + `#import` directive.
+Phase 2: Provider-aware missing-action diagnostics + decompile import recovery.
+Phase 3: CLI pack management and docs/search integration.
+Phase 4: Curated official pack set (Toolbox Pro, Nautomate, GizmoPack) and versioned compatibility policy.
+## Risks and mitigations
+Identifier drift in third-party apps: store pack version metadata and add compatibility matrix tests.
+Name collisions across ecosystems: enforce prefix/alias policy and deterministic resolver errors.
+Security/trust of third-party catalogs: no executable plugin code in v1; validate manifest schema strictly; prefer local/explicit pack installation.
+Maintenance burden: keep packs declarative and test-driven; avoid custom Go hooks unless a pack truly requires them.
+## Acceptance criteria
+A developer can install/import a third-party pack, call its actions with typed signatures, compile successfully, and decompile back to Cherri with pack imports preserved.
+Existing projects using only built-in actions continue to compile/decompile without behavior changes.

--- a/plans/import_functions.md
+++ b/plans/import_functions.md
@@ -34,7 +34,8 @@ For each pack: validate schema, resolve referenced files, and build in-memory in
 - `packByID`,
 - `actionToPack` (function identifier -> pack),
 - `shortcutIdentifierToPackAction` (full workflow identifier -> pack/function).
-Registry load must be deterministic (stable sort by path + pack id) and fail-fast on invalid manifest.
+Registry load must be deterministic (stable sort by path + pack id).
+Invalid discovered packs should be marked unusable and surfaced via diagnostics, but only packs explicitly imported by the current source file (or explicitly requested via CLI) should hard-fail the command.
 ### 3) Add explicit source-level imports for packs
 Introduce a new directive, `#import 'pack-id'` (or equivalent), parsed during pre-processing before action calls are validated.
 Implementation touchpoints:


### PR DESCRIPTION
## Summary
- add `plans/import_functions.md` with a comprehensive architecture and rollout plan for third-party Shortcut extension command support
- define a "Function Packs" mechanism covering manifest format, registry/discovery, `#import` integration, decompile round-tripping, CLI/docs/search integration, and tests
- map each proposed change to concrete code touchpoints in this repository

## Testing
- not run (documentation/plan-only change)

Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://www.warp.dev/oz)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces third‑party function packs: explicit imports, precedence rules, provider-aware resolution, action search with pack context, CLI pack management (list/info/dir) and decompile support to restore pack imports.
  * Includes starter packs to try pack-based actions.

* **Documentation**
  * Added comprehensive planning docs covering pack format, rollout phases, diagnostics, CLI and docs integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->